### PR TITLE
deprecated 'target' config

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -8,6 +8,6 @@
 		%svelte.head%
 	</head>
 	<body>
-		<div id="svelte">%svelte.body%</div>
+		<div>%svelte.body%</div>
 	</body>
 </html>

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -6,9 +6,6 @@ const config = {
 	kit: {
 		adapter: adapter(),
 
-		// hydrate the <div id="svelte"> element in src/app.html
-		target: '#svelte',
-
 		vite: {
 			server: {
 				fs: {


### PR DESCRIPTION
Following the install instructions, I stumbled on this when trying to explore the inner workings of SvelteKit.

<img width="787" alt="Screenshot 2022-05-04 at 19 27 30" src="https://user-images.githubusercontent.com/79457016/166744835-c0b6650e-b646-4c87-9bac-9531fb3a52a9.png">

I edited the template to match kit's current template.

Is this sandbox the preferred way to test out kit locally ? 
Would it be relevant to have a way to always get the latest template for testing, modulus the `package.json` commands, from kit itself ?
